### PR TITLE
Repalce repa with NDArray

### DIFF
--- a/fei-cocoapi.cabal
+++ b/fei-cocoapi.cabal
@@ -43,7 +43,6 @@ Library
                           , transformers-base
                           , aeson
                           , time < 2.0
-                          , repa
                           , aeson
                           , attoparsec
                           , lens
@@ -74,7 +73,6 @@ Executable imageutils
                             aeson,
                             optparse-applicative,
                             JuicyPixels,
-                            repa,
                             store,
                             hip,
                             Rasterific,

--- a/src/MXNet/Coco/Mask.hs
+++ b/src/MXNet/Coco/Mask.hs
@@ -1,33 +1,36 @@
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE TypeOperators   #-}
 module MXNet.Coco.Mask where
 
-import           Data.Array.Repa              ((:.) (..), Array, DIM1, DIM2,
-                                               DIM3, Z (..), extent)
-import           Data.Array.Repa.Repr.Unboxed
-import qualified Data.Vector.Storable         as SV (unsafeCast)
+import qualified Data.Vector.Storable as SV (unsafeCast)
 import           RIO
-import qualified RIO.ByteString               as BS
-import qualified RIO.Vector.Storable          as SV (Vector, map)
-import qualified RIO.Vector.Unboxed           as UV (convert, length)
+import qualified RIO.ByteString       as BS
+import qualified RIO.Vector.Storable  as SV (Vector, fromList, length, map)
 
+import           MXNet.Base           (NDArray, fromVector, ndshape, toVector)
 import           MXNet.Coco.Raw
 
 -- NOTE:
 -- mask should be of 3 dimension and in CWH order
 -- also assuming that CDouble has the same memory representation as Double
-type Mask = Array U DIM3 Word8
-type Area = Array U DIM1 Word32
-type Iou  = Array U DIM2 Double
-type BBox = Array U DIM2 Double
+type Mask = NDArray Word8  -- DIM3
+type Area = NDArray Double -- DIM1
+type Iou  = NDArray Double -- DIM2
+type BBox = NDArray Double -- DIM2
 type Poly = SV.Vector Double
 
 data CompactRLE = CompactRLE Int Int (NonEmpty BS.ByteString)
 
+data CocoError = SizeMismatch
+  deriving Show
+
+instance Exception CocoError
+
 encode :: Mask -> IO CompactRLE
 encode mask = do
-    let Z :. n :. w :. h = extent mask
-    -- assuming Word8 are identical with CUChar
-    rles <- rleEncode (SV.map fromIntegral $ UV.convert $ toUnboxed mask) h w n
+    [n, w, h] <- ndshape mask
+    bytes <- SV.map fromIntegral <$> toVector mask
+    rles  <- rleEncode bytes h w n
     CompactRLE h w <$> mapM rleToString rles
 
 decode :: CompactRLE -> IO Mask
@@ -35,10 +38,7 @@ decode im@(CompactRLE h w bss) = do
     let n = length bss
     rles <- frString im
     raw <- rleDecode rles h w
-    return $
-        fromUnboxed (Z :. n :. w :. h) $
-        UV.convert $
-        SV.map fromIntegral raw
+    fromVector [n, w, h] $ SV.map fromIntegral raw
 
 merge :: CompactRLE -> Bool -> IO CompactRLE
 merge im intersect = do
@@ -57,36 +57,36 @@ area im@(CompactRLE _ _ bss) = do
     let num = length bss
     rles <- frString im
     as <- rleArea rles num
-    -- assuming the area can be represented as Word32
-    return $
-        fromListUnboxed (Z :. num) $
-        map fromIntegral $ as
+    fromVector [num] $ SV.map fromIntegral $ SV.fromList as
 
 iouRLEs :: CompactRLE -> CompactRLE -> [Bool] -> IO Iou
 iouRLEs dt gt iscrowd = do
     dt_rles <- frString dt
     gt_rles <- frString gt
     ((m, n), arr) <- rleIou dt_rles gt_rles iscrowd
-    return $ fromListUnboxed (Z :. n :. m) arr
+    fromVector [n, m] $ SV.fromList arr
 
 iouBBs :: BBox -> BBox -> [Bool] -> IO Iou
 iouBBs bb1 bb2 iscrowd = do
-    let bb1' = BB $ SV.unsafeCast $ UV.convert $ toUnboxed bb1
-        bb2' = BB $ SV.unsafeCast $ UV.convert $ toUnboxed bb2
+    bb1' <- BB . SV.unsafeCast <$> toVector bb1
+    bb2' <- BB . SV.unsafeCast <$> toVector bb2
     ((m, n), arr) <- bbIou bb1' bb2' iscrowd
-    return $ fromListUnboxed (Z :. n :. m) arr
+    fromVector [n, m] $ SV.fromList arr
 
 toBBox :: CompactRLE -> IO BBox
 toBBox im = do
     rles <- frString im
     BB bb <- rleToBbox rles
-    let bb' = UV.convert $ SV.unsafeCast  bb
-    return $ fromUnboxed (Z :. UV.length bb' :. 4) bb'
+    fromVector [SV.length bb, 4] (SV.unsafeCast bb)
 
 frBBox :: BBox -> Int -> Int -> IO CompactRLE
 frBBox bb h w = do
-    rles <- rleFrBbox (BB $ SV.unsafeCast $ UV.convert $ toUnboxed bb) h w
-    CompactRLE h w <$> mapM rleToString rles
+    bb <- toVector bb
+    if SV.length bb /= (h * w * 4)
+        then throwM SizeMismatch
+        else do
+            rles <- rleFrBbox (BB $ SV.unsafeCast bb) h w
+            CompactRLE h w <$> mapM rleToString rles
 
 frPoly :: NonEmpty Poly -> Int -> Int -> IO CompactRLE
 frPoly polys h w = do


### PR DESCRIPTION
Repa can be more type-safe (typed DIM), but it has a few cons that converting back and forth between Uboxed and Boxed, and also awkward way to do transformations. We simply replace all with NDArray.